### PR TITLE
Limit maximum parallel deployments

### DIFF
--- a/OctopusPuppet.Cmd/BranchDeploymentOptions.cs
+++ b/OctopusPuppet.Cmd/BranchDeploymentOptions.cs
@@ -40,11 +40,11 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
-        [Option('s', "ShowDeploymentProgress",
+        [Option('s', "HideDeploymentProgress",
             SetName = "BranchDeployment",
             Default = true,
-            HelpText = "Show deployment progress")]
-        public bool ShowDeploymentProgress { get; set; }
+            HelpText = "Hide deployment progress")]
+        public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParalleDeployments",
             SetName = "BranchDeployment",

--- a/OctopusPuppet.Cmd/BranchDeploymentOptions.cs
+++ b/OctopusPuppet.Cmd/BranchDeploymentOptions.cs
@@ -40,6 +40,18 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
+        [Option('s', "ShowDeploymentProgress",
+            SetName = "BranchDeployment",
+            Default = true,
+            HelpText = "Show deployment progress")]
+        public bool ShowDeploymentProgress { get; set; }
+
+        [Option('p', "MaximumParalleDeployments",
+            SetName = "BranchDeployment",
+            Default = 4,
+            HelpText = "Maximum parallel deployments")]
+        public int MaximumParalleDeployments { get; set; }
+
         [Option("EnvironmentDeploymentPath",
             Required = false,
             Default = "",

--- a/OctopusPuppet.Cmd/DeployOptions.cs
+++ b/OctopusPuppet.Cmd/DeployOptions.cs
@@ -30,11 +30,11 @@ namespace OctopusPuppet.Cmd
             HelpText = "The environment to deploy to.")]
         public string TargetEnvironment { get; set; }
 
-        [Option('s', "ShowDeploymentProgress",
+        [Option('s', "HideDeploymentProgress",
             SetName = "Deploy",
             Default = true,
-            HelpText = "Show deployment progress")]
-        public bool ShowDeploymentProgress { get; set; }
+            HelpText = "Hide deployment progress")]
+        public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParalleDeployments",
             SetName = "Deploy",

--- a/OctopusPuppet.Cmd/DeployOptions.cs
+++ b/OctopusPuppet.Cmd/DeployOptions.cs
@@ -29,5 +29,17 @@ namespace OctopusPuppet.Cmd
             SetName = "Deploy",
             HelpText = "The environment to deploy to.")]
         public string TargetEnvironment { get; set; }
+
+        [Option('s', "ShowDeploymentProgress",
+            SetName = "Deploy",
+            Default = true,
+            HelpText = "Show deployment progress")]
+        public bool ShowDeploymentProgress { get; set; }
+
+        [Option('p', "MaximumParalleDeployments",
+            SetName = "Deploy",
+            Default = 4,
+            HelpText = "Maximum parallel deployments")]
+        public int MaximumParalleDeployments { get; set; }
     }
 }

--- a/OctopusPuppet.Cmd/MirrorEnvironmentOptions.cs
+++ b/OctopusPuppet.Cmd/MirrorEnvironmentOptions.cs
@@ -40,11 +40,11 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
-        [Option('s', "ShowDeploymentProgress",
+        [Option('s', "HideDeploymentProgress",
             SetName = "MirrorEnvironment",
             Default = true,
-            HelpText = "Show deployment progress")]
-        public bool ShowDeploymentProgress { get; set; }
+            HelpText = "Hide deployment progress")]
+        public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParalleDeployments",
             SetName = "MirrorEnvironment",

--- a/OctopusPuppet.Cmd/MirrorEnvironmentOptions.cs
+++ b/OctopusPuppet.Cmd/MirrorEnvironmentOptions.cs
@@ -40,6 +40,18 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
+        [Option('s', "ShowDeploymentProgress",
+            SetName = "MirrorEnvironment",
+            Default = true,
+            HelpText = "Show deployment progress")]
+        public bool ShowDeploymentProgress { get; set; }
+
+        [Option('p', "MaximumParalleDeployments",
+            SetName = "MirrorEnvironment",
+            Default = 4,
+            HelpText = "Maximum parallel deployments")]
+        public int MaximumParalleDeployments { get; set; }
+
         [Option("EnvironmentDeploymentPath",
             Required = false,
             Default = "",

--- a/OctopusPuppet.Cmd/Program.cs
+++ b/OctopusPuppet.Cmd/Program.cs
@@ -102,7 +102,7 @@ namespace OctopusPuppet.Cmd
 
             if (opts.Deploy)
             {
-                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
+                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.HideDeploymentProgress, opts.MaximumParalleDeployments);
             }
 
             return 0;
@@ -126,7 +126,7 @@ namespace OctopusPuppet.Cmd
 
             if (opts.Deploy)
             {
-                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
+                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.HideDeploymentProgress, opts.MaximumParalleDeployments);
             }
 
             return 0;
@@ -150,7 +150,7 @@ namespace OctopusPuppet.Cmd
 
             if (opts.Deploy)
             {
-                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
+                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.HideDeploymentProgress, opts.MaximumParalleDeployments);
             }
 
             return 0;
@@ -159,7 +159,7 @@ namespace OctopusPuppet.Cmd
         private static int Deploy(DeployOptions opts)
         {
             var environmentDeployment = LoadEnvironmentDeploy(opts.EnvironmentDeploymentPath);
-            return Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
+            return Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.HideDeploymentProgress, opts.MaximumParalleDeployments);
         }
 
         private static int CommandLineParsingError(IEnumerable<Error> errors)
@@ -205,7 +205,7 @@ namespace OctopusPuppet.Cmd
             File.WriteAllText(path, environmentDeploymentJson);
         }
 
-        private static int Deploy(string url, string apiKey, string targetEnvironment, EnvironmentDeployment environmentDeployment, bool showDeploymentProgress, int maximumParalleDeployments)
+        private static int Deploy(string url, string apiKey, string targetEnvironment, EnvironmentDeployment environmentDeployment, bool hideDeploymentProgress, int maximumParalleDeployments)
         {
             var environment = new Environment
             {
@@ -213,7 +213,7 @@ namespace OctopusPuppet.Cmd
                 Name = targetEnvironment
             };
 
-            var progress = showDeploymentProgress ? new ConsoleDeployProgress() : null;
+            var progress = hideDeploymentProgress ? null : new ConsoleDeployProgress();
             var componentVertexDeployer = new OctopusComponentVertexDeployer(url, apiKey, environment);
             var cancellationTokenSource = new CancellationTokenSource();
             var deploymentExecutor = new DeploymentExecutor(componentVertexDeployer, environmentDeployment, cancellationTokenSource.Token, progress, maximumParalleDeployments);
@@ -242,6 +242,8 @@ namespace OctopusPuppet.Cmd
                 .AddPostOptionsLine("    --Branch \"Master\"")
                 .AddPostOptionsLine("    [--Deploy]")
                 .AddPostOptionsLine("    [--EnvironmentDeploymentPath \"environmentDeployment.json\"]")
+                .AddPostOptionsLine("    [--MaximumParalleDeployments 4]")
+                .AddPostOptionsLine("    [--HideDeploymentProgress]")
                 .AddPostOptionsLine("")
                 .AddPostOptionsLine("  OctopusPuppet.Cmd MirrorEnvironment")
                 .AddPostOptionsLine("    --OctopusUrl \"http://octopus.test.com/\"")
@@ -251,6 +253,8 @@ namespace OctopusPuppet.Cmd
                 .AddPostOptionsLine("    --TargetEnvironment \"Test\"")
                 .AddPostOptionsLine("    [--Deploy]")
                 .AddPostOptionsLine("    [--EnvironmentDeploymentPath \"environmentDeployment.json\"]")
+                .AddPostOptionsLine("    [--MaximumParalleDeployments 4]")
+                .AddPostOptionsLine("    [--HideDeploymentProgress]")
                 .AddPostOptionsLine("")
                 .AddPostOptionsLine("  OctopusPuppet.Cmd Redeployment")
                 .AddPostOptionsLine("    --OctopusUrl \"http://octopus.test.com/\"")
@@ -259,12 +263,16 @@ namespace OctopusPuppet.Cmd
                 .AddPostOptionsLine("    --TargetEnvironment \"Development\"")
                 .AddPostOptionsLine("    [--Deploy]")
                 .AddPostOptionsLine("    [--EnvironmentDeploymentPath \"environmentDeployment.json\"]")
+                .AddPostOptionsLine("    [--MaximumParalleDeployments 4]")
+                .AddPostOptionsLine("    [--HideDeploymentProgress]")
                 .AddPostOptionsLine("")
                 .AddPostOptionsLine("  OctopusPuppet.Cmd Deploy")
                 .AddPostOptionsLine("    --OctopusUrl \"http://octopus.test.com/\"")
                 .AddPostOptionsLine("    --OctopusApiKey \"API-HAAAS4MM6YBBSAIQVVHCQQUEA0\"")
                 .AddPostOptionsLine("    --EnvironmentDeploymentPath \"environmentDeployment.json\"")
                 .AddPostOptionsLine("    --TargetEnvironment \"Development\"")
+                .AddPostOptionsLine("    [--MaximumParalleDeployments 4]")
+                .AddPostOptionsLine("    [--HideDeploymentProgress]")
                 .AddPostOptionsLine("");
 
             HelpText.DefaultParsingErrorsHandler(parserResult, helpText);

--- a/OctopusPuppet.Cmd/Program.cs
+++ b/OctopusPuppet.Cmd/Program.cs
@@ -102,7 +102,7 @@ namespace OctopusPuppet.Cmd
 
             if (opts.Deploy)
             {
-                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment);
+                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
             }
 
             return 0;
@@ -126,7 +126,7 @@ namespace OctopusPuppet.Cmd
 
             if (opts.Deploy)
             {
-                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment);
+                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
             }
 
             return 0;
@@ -150,7 +150,7 @@ namespace OctopusPuppet.Cmd
 
             if (opts.Deploy)
             {
-                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment);
+                Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
             }
 
             return 0;
@@ -159,7 +159,7 @@ namespace OctopusPuppet.Cmd
         private static int Deploy(DeployOptions opts)
         {
             var environmentDeployment = LoadEnvironmentDeploy(opts.EnvironmentDeploymentPath);
-            return Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment);
+            return Deploy(opts.OctopusUrl, opts.OctopusApiKey, opts.TargetEnvironment, environmentDeployment, opts.ShowDeploymentProgress, opts.MaximumParalleDeployments);
         }
 
         private static int CommandLineParsingError(IEnumerable<Error> errors)
@@ -205,7 +205,7 @@ namespace OctopusPuppet.Cmd
             File.WriteAllText(path, environmentDeploymentJson);
         }
 
-        private static int Deploy(string url, string apiKey, string targetEnvironment, EnvironmentDeployment environmentDeployment)
+        private static int Deploy(string url, string apiKey, string targetEnvironment, EnvironmentDeployment environmentDeployment, bool showDeploymentProgress, int maximumParalleDeployments)
         {
             var environment = new Environment
             {
@@ -213,9 +213,10 @@ namespace OctopusPuppet.Cmd
                 Name = targetEnvironment
             };
 
+            var progress = showDeploymentProgress ? new ConsoleDeployProgress() : null;
             var componentVertexDeployer = new OctopusComponentVertexDeployer(url, apiKey, environment);
             var cancellationTokenSource = new CancellationTokenSource();
-            var deploymentExecutor = new DeploymentExecutor(componentVertexDeployer, environmentDeployment, cancellationTokenSource.Token, null);
+            var deploymentExecutor = new DeploymentExecutor(componentVertexDeployer, environmentDeployment, cancellationTokenSource.Token, progress, maximumParalleDeployments);
             deploymentExecutor.Execute().ConfigureAwait(false).GetAwaiter().GetResult();
 
             return 0;

--- a/OctopusPuppet.Cmd/RedploymentOptions.cs
+++ b/OctopusPuppet.Cmd/RedploymentOptions.cs
@@ -34,6 +34,18 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
+        [Option('s', "ShowDeploymentProgress",
+            SetName = "Redeployment",
+            Default = true,
+            HelpText = "Show deployment progress")]
+        public bool ShowDeploymentProgress { get; set; }
+
+        [Option('p', "MaximumParalleDeployments",
+            SetName = "Redeployment",
+            Default = 4,
+            HelpText = "Maximum parallel deployments")]
+        public int MaximumParalleDeployments { get; set; }
+
         [Option("EnvironmentDeploymentPath",
             Required = false,
             Default = "",

--- a/OctopusPuppet.Cmd/RedploymentOptions.cs
+++ b/OctopusPuppet.Cmd/RedploymentOptions.cs
@@ -34,11 +34,11 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
-        [Option('s', "ShowDeploymentProgress",
+        [Option('s', "HideDeploymentProgress",
             SetName = "Redeployment",
             Default = true,
-            HelpText = "Show deployment progress")]
-        public bool ShowDeploymentProgress { get; set; }
+            HelpText = "Hide deployment progress")]
+        public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParalleDeployments",
             SetName = "Redeployment",


### PR DESCRIPTION
Added functionality to limit the number of parallel deployments, as we don't want to block Octopus with 1 environments deployment. Octopus normally doesn't allow parallel deployments onto the same machine.