### PR TITLE
Toggle all feature for all variables and all deployment actions

### DIFF
--- a/src/OctopusPuppet.Gui/Model/ComponentDeploymentResult.cs
+++ b/src/OctopusPuppet.Gui/Model/ComponentDeploymentResult.cs
@@ -10,6 +10,11 @@ namespace OctopusPuppet.Gui.Model
     {
         public static implicit operator ComponentDeploymentResult(ComponentDeployment componentDeployment)
         {
+            if (componentDeployment == null)
+            {
+                return null;
+            }
+
             return new ComponentDeploymentResult
             {
                 Vertex = componentDeployment.Vertex,

--- a/src/OctopusPuppet.Gui/Model/EnvironmentDeploymentResult.cs
+++ b/src/OctopusPuppet.Gui/Model/EnvironmentDeploymentResult.cs
@@ -9,6 +9,11 @@ namespace OctopusPuppet.Gui.Model
     {
         public static implicit operator EnvironmentDeploymentResult(EnvironmentDeployment environmentDeployment)
         {
+            if (environmentDeployment == null)
+            {
+                return null;
+            }
+
             return new EnvironmentDeploymentResult(new List<ProductDeploymentResult>())
             {
                 ProductDeployments = environmentDeployment.ProductDeployments.Select(x => (ProductDeploymentResult)x).ToList()

--- a/src/OctopusPuppet.Gui/Model/ProductDeploymentResult.cs
+++ b/src/OctopusPuppet.Gui/Model/ProductDeploymentResult.cs
@@ -9,6 +9,11 @@ namespace OctopusPuppet.Gui.Model
     {
         public static implicit operator ProductDeploymentResult(ProductDeployment productDeployment)
         {
+            if (productDeployment == null)
+            {
+                return null;
+            }
+
             return new ProductDeploymentResult(new List<ProductDeploymentStepResult>())
             {
                 DeploymentSteps = productDeployment.DeploymentSteps.Select(x => (ProductDeploymentStepResult)x).ToList()

--- a/src/OctopusPuppet.Gui/Model/ProductDeploymentStepResult.cs
+++ b/src/OctopusPuppet.Gui/Model/ProductDeploymentStepResult.cs
@@ -9,6 +9,11 @@ namespace OctopusPuppet.Gui.Model
     {
         public static implicit operator ProductDeploymentStepResult(ProductDeploymentStep productDeploymentStep)
         {
+            if (productDeploymentStep == null)
+            {
+                return null;
+            }
+
             return new ProductDeploymentStepResult(new List<ComponentDeploymentResult>())
             {
                 ExecutionOrder = productDeploymentStep.ExecutionOrder,

--- a/src/OctopusPuppet.Gui/OctopusPuppet.Gui.csproj
+++ b/src/OctopusPuppet.Gui/OctopusPuppet.Gui.csproj
@@ -151,6 +151,7 @@
     <Compile Include="ViewModels\StringWrapper.cs" />
     <Compile Include="Views\ComponentGraphLayout.cs" />
     <Compile Include="ViewModels\DeploymentPlannerViewModel.cs" />
+    <Compile Include="Views\DataContextSpy.cs" />
     <Compile Include="Views\DeploymentPlannerView.xaml.cs">
       <DependentUpon>DeploymentPlannerView.xaml</DependentUpon>
     </Compile>

--- a/src/OctopusPuppet.Gui/ViewModels/DeploymentPlannerViewModel.cs
+++ b/src/OctopusPuppet.Gui/ViewModels/DeploymentPlannerViewModel.cs
@@ -778,12 +778,12 @@ namespace OctopusPuppet.Gui.ViewModels
 
             foreach (var componentToDeploy in componentsToDeploy)
             {
-                componentToDeploy.Vertex.DeploymentAction = SelectedSetAllDeploymentsTo;
+                componentToDeploy.Vertex.DeploymentAction = PlanAction.Skip;
             }
 
             foreach (var deploymentPlan in deploymentPlans)
             {
-                deploymentPlan.Action = SelectedSetAllDeploymentsTo;
+                deploymentPlan.Action = PlanAction.Skip;
             }
 
             if (successfullyDeployedComponents.Any())

--- a/src/OctopusPuppet.Gui/Views/DataContextSpy.cs
+++ b/src/OctopusPuppet.Gui/Views/DataContextSpy.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Data;
+
+namespace OctopusPuppet.Gui.Views
+{
+    public class DataContextSpy
+        : Freezable // Enable ElementName and DataContext bindings
+    {
+        public DataContextSpy()
+        {
+            // This binding allows the spy to inherit a DataContext.
+            BindingOperations.SetBinding(this, DataContextProperty, new Binding());
+
+            this.IsSynchronizedWithCurrentItem = true;
+        }
+
+        /// <summary>
+        /// Gets/sets whether the spy will return the CurrentItem of the 
+        /// ICollectionView that wraps the data context, assuming it is
+        /// a collection of some sort.  If the data context is not a 
+        /// collection, this property has no effect. 
+        /// The default value is true.
+        /// </summary>
+        public bool IsSynchronizedWithCurrentItem { get; set; }
+
+        public object DataContext
+        {
+            get { return (object)GetValue(DataContextProperty); }
+            set { SetValue(DataContextProperty, value); }
+        }
+
+        // Borrow the DataContext dependency property from FrameworkElement.
+        public static readonly DependencyProperty DataContextProperty =
+            FrameworkElement.DataContextProperty.AddOwner(
+                typeof(DataContextSpy),
+                new PropertyMetadata(null, null, OnCoerceDataContext));
+
+        static object OnCoerceDataContext(DependencyObject depObj, object value)
+        {
+            DataContextSpy spy = depObj as DataContextSpy;
+            if (spy == null)
+                return value;
+
+            if (spy.IsSynchronizedWithCurrentItem)
+            {
+                ICollectionView view = CollectionViewSource.GetDefaultView(value);
+                if (view != null)
+                    return view.CurrentItem;
+            }
+
+            return value;
+        }
+
+        protected override Freezable CreateInstanceCore()
+        {
+            // We are required to override this abstract method.
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OctopusPuppet.Gui/Views/DeploymentPlannerView.xaml
+++ b/src/OctopusPuppet.Gui/Views/DeploymentPlannerView.xaml
@@ -14,6 +14,7 @@
             xmlns:sd="http://icsharpcode.net/sharpdevelop/treeview"
             xmlns:tree="clr-namespace:Aga.Controls.Tree;assembly=Aga.Controls"
             xmlns:model="clr-namespace:OctopusPuppet.Gui.Model"
+            xmlns:cal="http://www.caliburnproject.org"
 
             mc:Ignorable="d" 
              d:DesignHeight="768" d:DesignWidth="768"
@@ -29,6 +30,7 @@
                 <x:Type TypeName="deploymentPlanner:VariableAction" />
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+        <views:DataContextSpy x:Key="Spy" />
     </UserControl.Resources>
     <TabControl>
         <TabItem Header="Generate Deployment Plan">
@@ -182,158 +184,201 @@
                                         <Button x:Name="LoadEnvironmentDeploymentJson" Content="Load" VerticalAlignment="Center" Margin="10" Padding="10 3" />
                                     </StackPanel>
                                     <tree:TreeList Name="EnvironmentDeploymentTreeList" Model="{Binding EnvironmentDeployment}" HorizontalAlignment="Stretch" tree:GridViewColumnResize.Enabled="True" IsExpanded="True">
-                                        <tree:TreeList.ItemTemplate>
-                                            <DataTemplate>
-                                                <ContentControl Content="{Binding}">
-                                                    <ContentControl.Resources>
-                                                        <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}" >
-                                                        </HierarchicalDataTemplate>
-                                                        <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
-                                                            <StackPanel Orientation="Horizontal">
-                                                                <tree:RowExpander/>
-                                                                <TextBlock Text="Step - " />
-                                                                <TextBlock Text="{Binding ExecutionOrder}" />
-                                                            </StackPanel>
-                                                        </HierarchicalDataTemplate>
-                                                        <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
-                                                            <StackPanel Orientation="Horizontal">
-                                                                <tree:RowExpander/>
-                                                                <TextBlock Text="{Binding Vertex.Name}" />
-                                                            </StackPanel>
-                                                        </DataTemplate>
-                                                    </ContentControl.Resources>
-                                                </ContentControl>
-                                            </DataTemplate>
-                                        </tree:TreeList.ItemTemplate>
-                                        <tree:TreeList.View>
-                                            <GridView>
-                                                <GridViewColumn Header="Name" tree:GridViewColumnResize.Width="*">
-                                                    <GridViewColumn.CellTemplate>
-                                                        <DataTemplate>
-                                                            <ContentControl Content="{Binding}">
-                                                                <ContentControl.Resources>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <tree:RowExpander/>
-                                                                            <TextBlock Text="Product" HorizontalAlignment="Stretch" />
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <tree:RowExpander/>
-                                                                            <TextBlock Text="Step - " />
-                                                                            <TextBlock Text="{Binding ExecutionOrder}" />
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <tree:RowExpander/>
-                                                                            <TextBlock Text="{Binding Vertex.Name}" />
-                                                                        </StackPanel>
-                                                                    </DataTemplate>
-                                                                </ContentControl.Resources>
-                                                            </ContentControl>
-                                                        </DataTemplate>
-                                                    </GridViewColumn.CellTemplate>
-                                                </GridViewColumn>
-                                                <GridViewColumn Header="Version" Width="125">
-                                                    <GridViewColumn.CellTemplate>
-                                                        <DataTemplate>
-                                                            <ContentControl Content="{Binding}">
-                                                                <ContentControl.Resources>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
-                                                                        <StackPanel Orientation="Horizontal">
+                                    <tree:TreeList.ItemTemplate>
+                                        <DataTemplate>
+                                            <ContentControl Content="{Binding}">
+                                                <ContentControl.Resources>
+                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}" >
+                                                    </HierarchicalDataTemplate>
+                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <tree:RowExpander/>
+                                                            <TextBlock Text="Step - " />
+                                                            <TextBlock Text="{Binding ExecutionOrder}" />
+                                                        </StackPanel>
+                                                    </HierarchicalDataTemplate>
+                                                    <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <tree:RowExpander/>
+                                                            <TextBlock Text="{Binding Vertex.Name}" />
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </ContentControl.Resources>
+                                            </ContentControl>
+                                        </DataTemplate>
+                                    </tree:TreeList.ItemTemplate>
+                                    <tree:TreeList.View>
+                                        <GridView>
+                                            <GridViewColumn tree:GridViewColumnResize.Width="*">
+                                                <GridViewColumn.HeaderTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel>
+                                                            <TextBlock Text="Name" />
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </GridViewColumn.HeaderTemplate>
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl Content="{Binding}">
+                                                            <ContentControl.Resources>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <tree:RowExpander/>
+                                                                        <TextBlock Text="Product" HorizontalAlignment="Stretch" />
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <tree:RowExpander/>
+                                                                        <TextBlock Text="Step - " />
+                                                                        <TextBlock Text="{Binding ExecutionOrder}" />
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <tree:RowExpander/>
+                                                                        <TextBlock Text="{Binding Vertex.Name}" />
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ContentControl.Resources>
+                                                        </ContentControl>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
+                                            <GridViewColumn Width="125">
+                                                <GridViewColumn.HeaderTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel>
+                                                            <TextBlock Text="Version" />
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </GridViewColumn.HeaderTemplate>
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl Content="{Binding}">
+                                                            <ContentControl.Resources>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
+                                                                    <StackPanel Orientation="Horizontal">
 
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
-                                                                        <StackPanel Orientation="Horizontal">
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
+                                                                    <StackPanel Orientation="Horizontal">
 
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <TextBlock Text="{Binding Vertex.Version}" />
-                                                                        </StackPanel>
-                                                                    </DataTemplate>
-                                                                </ContentControl.Resources>
-                                                            </ContentControl>
-                                                        </DataTemplate>
-                                                    </GridViewColumn.CellTemplate>
-                                                </GridViewColumn>
-                                                <GridViewColumn Header="Duration" Width="125">
-                                                    <GridViewColumn.CellTemplate>
-                                                        <DataTemplate>
-                                                            <ContentControl Content="{Binding}">
-                                                                <ContentControl.Resources>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <TextBlock Text="{Binding DeploymentDuration}" />
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <TextBlock Text="{Binding DeploymentDuration}" />
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <TextBlock Text="{Binding Vertex.DeploymentDuration}" />
-                                                                        </StackPanel>
-                                                                    </DataTemplate>
-                                                                </ContentControl.Resources>
-                                                            </ContentControl>
-                                                        </DataTemplate>
-                                                    </GridViewColumn.CellTemplate>
-                                                </GridViewColumn>
-                                                <GridViewColumn Header="Variables" Width="80">
-                                                    <GridViewColumn.CellTemplate>
-                                                        <DataTemplate>
-                                                            <ContentControl Content="{Binding}">
-                                                                <ContentControl.Resources>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <ComboBox SelectedItem="{Binding Vertex.VariableAction, Mode=TwoWay}" ItemsSource="{Binding Source={StaticResource VariableActionTypeValues}}"/>
-                                                                        </StackPanel>
-                                                                    </DataTemplate>
-                                                                </ContentControl.Resources>
-                                                            </ContentControl>
-                                                        </DataTemplate>
-                                                    </GridViewColumn.CellTemplate>
-                                                </GridViewColumn>
-                                                <GridViewColumn Header="Deployment" Width="100">
-                                                    <GridViewColumn.CellTemplate>
-                                                        <DataTemplate>
-                                                            <ContentControl Content="{Binding}">
-                                                                <ContentControl.Resources>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                        </StackPanel>
-                                                                    </HierarchicalDataTemplate>
-                                                                    <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
-                                                                        <StackPanel Orientation="Horizontal">
-                                                                            <ComboBox SelectedItem="{Binding Vertex.DeploymentAction, Mode=TwoWay}" ItemsSource="{Binding Source={StaticResource PlanActionTypeValues}}"/>
-                                                                        </StackPanel>
-                                                                    </DataTemplate>
-                                                                </ContentControl.Resources>
-                                                            </ContentControl>
-                                                        </DataTemplate>
-                                                    </GridViewColumn.CellTemplate>
-                                                </GridViewColumn>
-                                            </GridView>
-                                        </tree:TreeList.View>
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <TextBlock Text="{Binding Vertex.Version}" />
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ContentControl.Resources>
+                                                        </ContentControl>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
+                                            <GridViewColumn Width="125">
+                                                <GridViewColumn.HeaderTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel>
+                                                            <TextBlock Text="Duration" />
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </GridViewColumn.HeaderTemplate>
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl Content="{Binding}">
+                                                            <ContentControl.Resources>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <TextBlock Text="{Binding DeploymentDuration}" />
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <TextBlock Text="{Binding DeploymentDuration}" />
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <TextBlock Text="{Binding Vertex.DeploymentDuration}" />
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ContentControl.Resources>
+                                                        </ContentControl>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
+                                            <GridViewColumn Width="120">
+                                                <GridViewColumn.HeaderTemplate >
+                                                    <DataTemplate>
+                                                        <StackPanel>
+                                                            <TextBlock Text="Variables" />
+                                                            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" VerticalAlignment="Top" >
+                                                                <ComboBox SelectedItem="{Binding Source={StaticResource Spy}, Path=DataContext.SelectedSetVariablesTo, Mode=TwoWay}" ItemsSource="{Binding Source={StaticResource VariableActionTypeValues}}" MinWidth="70"/>
+                                                                <Button x:Name="SetAllVariablesTo" Content="Set" VerticalAlignment="Center" Margin="2" Padding="10 3" cal:Message.Attach="SetAllVariablesTo"/>
+                                                            </StackPanel>
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </GridViewColumn.HeaderTemplate>
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl Content="{Binding}">
+                                                            <ContentControl.Resources>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <ComboBox SelectedItem="{Binding Vertex.VariableAction, Mode=TwoWay}" ItemsSource="{Binding Source={StaticResource VariableActionTypeValues}}"/>
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ContentControl.Resources>
+                                                        </ContentControl>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
+                                            <GridViewColumn Width="120">
+                                                <GridViewColumn.HeaderTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel>
+                                                            <TextBlock Text="Deployment" />
+                                                            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" VerticalAlignment="Top" >
+                                                                <ComboBox SelectedItem="{Binding Source={StaticResource Spy}, Path=DataContext.SelectedSetAllDeploymentsTo, Mode=TwoWay}" ItemsSource="{Binding Source={StaticResource PlanActionTypeValues}}" MinWidth="70"/>
+                                                                <Button x:Name="SetAllDeploymentsTo" Content="Set" VerticalAlignment="Center" Margin="2" Padding="10 3" cal:Message.Attach="SetAllDeploymentsTo"  />
+                                                            </StackPanel>
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </GridViewColumn.HeaderTemplate>
+                                                <GridViewColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <ContentControl Content="{Binding}">
+                                                            <ContentControl.Resources>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeployment}" ItemsSource="{Binding DeploymentSteps}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <HierarchicalDataTemplate DataType="{x:Type scheduler:ProductDeploymentStep}" ItemsSource="{Binding ComponentDeployments}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                    </StackPanel>
+                                                                </HierarchicalDataTemplate>
+                                                                <DataTemplate DataType="{x:Type scheduler:ComponentDeployment}">
+                                                                    <StackPanel Orientation="Horizontal">
+                                                                        <ComboBox SelectedItem="{Binding Vertex.DeploymentAction, Mode=TwoWay}" ItemsSource="{Binding Source={StaticResource PlanActionTypeValues}}"/>
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ContentControl.Resources>
+                                                        </ContentControl>
+                                                    </DataTemplate>
+                                                </GridViewColumn.CellTemplate>
+                                            </GridViewColumn>
+                                        </GridView>
+                                    </tree:TreeList.View>
                                     </tree:TreeList>
                                 </DockPanel>
                             </Grid>


### PR DESCRIPTION
Provide a way for people to toggle all variables actions
Provide a way for people to toggle all deployment actions
When a component has been deployed successfully, then marked it as skipped in the GUI. This will mean that when fixing and retrying it will only redeploy the failed ones.
