### PR TITLE
Add a command line switch that will allow you to enable/disable differential deployment

### DIFF
--- a/src/OctopusPuppet.Cmd/BranchDeploymentOptions.cs
+++ b/src/OctopusPuppet.Cmd/BranchDeploymentOptions.cs
@@ -47,6 +47,12 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
+        [Option('f', "DoNotUseDifferentialDeployment",
+            Default = false,
+            SetName = "BranchDeployment",
+            HelpText = "Do not use differential deployment")]
+        public bool DoNotUseDifferentialDeployment { get; set; }
+
         [Option('u', "UpdateVariables",
              Default = false,
              SetName = "BranchDeployment",
@@ -60,7 +66,7 @@ namespace OctopusPuppet.Cmd
         public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParallelDeployments",
-            Default = 4,
+            Default = 2,
             SetName = "BranchDeployment",
             HelpText = "Maximum parallel deployments")]
         public int MaximumParallelDeployments { get; set; }

--- a/src/OctopusPuppet.Cmd/DeployOptions.cs
+++ b/src/OctopusPuppet.Cmd/DeployOptions.cs
@@ -37,7 +37,7 @@ namespace OctopusPuppet.Cmd
         public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParallelDeployments",
-            Default = 4,
+            Default = 2,
             SetName = "Deploy",
             HelpText = "Maximum parallel deployments")]
         public int MaximumParallelDeployments { get; set; }

--- a/src/OctopusPuppet.Cmd/MirrorEnvironmentOptions.cs
+++ b/src/OctopusPuppet.Cmd/MirrorEnvironmentOptions.cs
@@ -47,6 +47,12 @@ namespace OctopusPuppet.Cmd
             HelpText = "Deploy")]
         public bool Deploy { get; set; }
 
+        [Option('f', "DoNotUseDifferentialDeployment",
+            Default = false,
+            SetName = "MirrorEnvironment",
+            HelpText = "Do not use differential deployment")]
+        public bool DoNotUseDifferentialDeployment { get; set; }
+
         [Option('u', "UpdateVariables",
              Default = false,
              SetName = "MirrorEnvironment",
@@ -60,7 +66,7 @@ namespace OctopusPuppet.Cmd
         public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParallelDeployments",
-            Default = 4,
+            Default = 2,
             SetName = "MirrorEnvironment",
             HelpText = "Maximum parallel deployments")]
         public int MaximumParalleDeployments { get; set; }

--- a/src/OctopusPuppet.Cmd/Program.cs
+++ b/src/OctopusPuppet.Cmd/Program.cs
@@ -93,7 +93,7 @@ namespace OctopusPuppet.Cmd
             var componentFilter = GetComponentFilter(opts.ComponentFilterPath, opts.ComponentFilter);
 
             notifier.PrintActionMessage(string.Format("Retrieve branch deployment plans for TargetEnvironment=\"{0}\" Branch=\"{1}\"", opts.TargetEnvironment, opts.Branch));
-            var redeployDeploymentPlans = deploymentPlanner.GetBranchDeploymentPlans(opts.TargetEnvironment, opts.Branch, componentFilter);
+            var redeployDeploymentPlans = deploymentPlanner.GetBranchDeploymentPlans(opts.TargetEnvironment, opts.Branch, opts.DoNotUseDifferentialDeployment, componentFilter);
             var environmentDeploymentPlan = redeployDeploymentPlans.EnvironmentDeploymentPlan;
 
             var deploymentScheduler = new DeploymentScheduler();
@@ -118,7 +118,7 @@ namespace OctopusPuppet.Cmd
             var componentFilter = GetComponentFilter(opts.ComponentFilterPath, opts.ComponentFilter);
 
             notifier.PrintActionMessage(string.Format("Retrieve mirror environment plans for SourceEnvironment=\"{0}\" TargetEnvironment=\"{1}\"", opts.SourceEnvironment, opts.TargetEnvironment));
-            var environmentMirrorDeploymentPlans = deploymentPlanner.GetEnvironmentMirrorDeploymentPlans(opts.SourceEnvironment, opts.TargetEnvironment, componentFilter);
+            var environmentMirrorDeploymentPlans = deploymentPlanner.GetEnvironmentMirrorDeploymentPlans(opts.SourceEnvironment, opts.TargetEnvironment, opts.DoNotUseDifferentialDeployment, componentFilter);
             var environmentDeploymentPlan = environmentMirrorDeploymentPlans.EnvironmentDeploymentPlan;
 
             var deploymentScheduler = new DeploymentScheduler();
@@ -264,6 +264,7 @@ namespace OctopusPuppet.Cmd
                 .AddPostOptionsLine("    [--ComponentFilterPath \"componentFilter.json\"]")
                 .AddPostOptionsLine("    [--ComponentFilter \"Component filter json base64 encoded\"]")
                 .AddPostOptionsLine("    [--Deploy]")
+                .AddPostOptionsLine("    [--DoNotUseDifferentialDeployment]")
                 .AddPostOptionsLine("    [--UpdateVariables]")
                 .AddPostOptionsLine("    [--EnvironmentDeploymentPath \"environmentDeployment.json\"]")
                 .AddPostOptionsLine("    [--MaximumParallelDeployments 4]")
@@ -277,6 +278,7 @@ namespace OctopusPuppet.Cmd
                 .AddPostOptionsLine("    [--ComponentFilterPath \"componentFilter.json\"]")
                 .AddPostOptionsLine("    [--ComponentFilter \"Component filter json base64 encoded\"]")
                 .AddPostOptionsLine("    [--Deploy]")
+                .AddPostOptionsLine("    [--DoNotUseDifferentialDeployment]")
                 .AddPostOptionsLine("    [--UpdateVariables]")
                 .AddPostOptionsLine("    [--EnvironmentDeploymentPath \"environmentDeployment.json\"]")
                 .AddPostOptionsLine("    [--MaximumParallelDeployments 4]")

--- a/src/OctopusPuppet.Cmd/RedploymentOptions.cs
+++ b/src/OctopusPuppet.Cmd/RedploymentOptions.cs
@@ -54,7 +54,7 @@ namespace OctopusPuppet.Cmd
         public bool HideDeploymentProgress { get; set; }
 
         [Option('p', "MaximumParallelDeployments",
-            Default = 4,
+            Default = 2,
             SetName = "Redeployment",
             HelpText = "Maximum parallel deployments")]
         public int MaximumParalleDeployments { get; set; }

--- a/src/OctopusPuppet.Gui/ViewModels/DeploymentPlannerViewModel.cs
+++ b/src/OctopusPuppet.Gui/ViewModels/DeploymentPlannerViewModel.cs
@@ -277,6 +277,18 @@ namespace OctopusPuppet.Gui.ViewModels
             }
         }
 
+        private bool _doNotUseDifferentialDeploymentForBranchDeployment = false;
+        public bool DoNotUseDifferentialDeploymentForBranchDeployment
+        {
+            get { return _doNotUseDifferentialDeploymentForBranchDeployment; }
+            set
+            {
+                if (value == _doNotUseDifferentialDeploymentForBranchDeployment) return;
+                _doNotUseDifferentialDeploymentForBranchDeployment = value;
+                NotifyOfPropertyChange(() => DoNotUseDifferentialDeploymentForBranchDeployment);
+            }
+        }
+
         private List<Environment> _redeploymentEnvironments;
         public List<Environment> RedeploymentEnvironments
         {
@@ -352,6 +364,18 @@ namespace OctopusPuppet.Gui.ViewModels
                 NotifyOfPropertyChange(() => SelectedEnvironmentMirrorToEnvironment);
 
                 NotifyOfPropertyChange(() => CanEnvironmentMirror);
+            }
+        }
+
+        private bool _doNotUseDifferentialDeploymentForMirror = false;
+        public bool DoNotUseDifferentialDeploymentForMirror
+        {
+            get { return _doNotUseDifferentialDeploymentForMirror; }
+            set
+            {
+                if (value == _doNotUseDifferentialDeploymentForMirror) return;
+                _doNotUseDifferentialDeploymentForMirror = value;
+                NotifyOfPropertyChange(() => DoNotUseDifferentialDeploymentForMirror);
             }
         }
 
@@ -469,7 +493,7 @@ namespace OctopusPuppet.Gui.ViewModels
                         Include = ComponentFilterInclude
                     };
 
-                    var branchDeploymentPlans = deploymentPlanner.GetBranchDeploymentPlans(_selectedBranchDeploymentEnvironment.Name, _selectedBranchDeploymentBranch.Name, componentFilter);
+                    var branchDeploymentPlans = deploymentPlanner.GetBranchDeploymentPlans(_selectedBranchDeploymentEnvironment.Name, _selectedBranchDeploymentBranch.Name, _doNotUseDifferentialDeploymentForBranchDeployment, componentFilter);
                     EnvironmentDeploymentPlan = branchDeploymentPlans.EnvironmentDeploymentPlan;
 
                     var deploymentScheduler = new DeploymentScheduler();
@@ -569,7 +593,7 @@ namespace OctopusPuppet.Gui.ViewModels
                         Expressions = ComponentFilterExpressions.Select(x => x.Text).ToList(),
                         Include = ComponentFilterInclude
                     };
-                    var environmentMirrorDeploymentPlans = deploymentPlanner.GetEnvironmentMirrorDeploymentPlans(_selectedEnvironmentMirrorFromEnvironment.Name, _selectedEnvironmentMirrorToEnvironment.Name, componentFilter);
+                    var environmentMirrorDeploymentPlans = deploymentPlanner.GetEnvironmentMirrorDeploymentPlans(_selectedEnvironmentMirrorFromEnvironment.Name, _selectedEnvironmentMirrorToEnvironment.Name, _doNotUseDifferentialDeploymentForMirror, componentFilter);
 
                     EnvironmentDeploymentPlan = environmentMirrorDeploymentPlans.EnvironmentDeploymentPlan;
 

--- a/src/OctopusPuppet.Gui/Views/DeploymentPlannerView.xaml
+++ b/src/OctopusPuppet.Gui/Views/DeploymentPlannerView.xaml
@@ -69,6 +69,8 @@
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
 
@@ -78,7 +80,10 @@
                                                 <Label Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center" Content="To"/>
                                                 <ComboBox Grid.Column="3" x:Name="BranchDeploymentEnvironments" SelectedItem="{Binding SelectedBranchDeploymentEnvironment}" DisplayMemberPath="Name" SelectedValuePath="Id" HorizontalAlignment="Left" VerticalAlignment="Center" MinWidth="150"/>
 
-                                                <Button Grid.Column="4" x:Name="BranchDeployment" Content="Get" HorizontalAlignment="left" VerticalAlignment="Center" Margin="10" Padding="10 3" />
+                                                <Label Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center" Content="Do not use differential deploy"/>
+                                                <CheckBox Grid.Column="5" HorizontalAlignment="Right" VerticalAlignment="Center" IsChecked="{Binding DoNotUseDifferentialDeploymentForBranchDeployment, Mode=TwoWay}" ></CheckBox>
+                                                
+                                                <Button Grid.Column="6" x:Name="BranchDeployment" Content="Get" HorizontalAlignment="left" VerticalAlignment="Center" Margin="10" Padding="10 3" />
                                             </Grid>
                                         </GroupBox>
                                         <GroupBox Header="Redeployment" Margin="10">
@@ -104,6 +109,8 @@
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                                                     <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
+                                                    <ColumnDefinition Width="Auto" SharedSizeGroup="Label"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
 
@@ -113,7 +120,10 @@
                                                 <Label Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center" Content="To"/>
                                                 <ComboBox Grid.Column="3" x:Name="EnvironmentMirrorToEnvironments" SelectedItem="{Binding SelectedEnvironmentMirrorToEnvironment}" DisplayMemberPath="Name" SelectedValuePath="Id" HorizontalAlignment="Left" VerticalAlignment="Center" MinWidth="150"/>
 
-                                                <Button Grid.Column="4" x:Name="EnvironmentMirror" Content="Get" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Padding="10 3"/>
+                                                <Label Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center" Content="Do not use differential deploy"/>
+                                                <CheckBox Grid.Column="5" HorizontalAlignment="Right" VerticalAlignment="Center" IsChecked="{Binding DoNotUseDifferentialDeploymentForMirror, Mode=TwoWay}" ></CheckBox>
+
+                                                <Button Grid.Column="6" x:Name="EnvironmentMirror" Content="Get" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Padding="10 3"/>
                                             </Grid>
                                         </GroupBox>
                                     </StackPanel>

--- a/src/OctopusPuppet.IntegrationTests/OctopusDeploymentPlannerTests.cs
+++ b/src/OctopusPuppet.IntegrationTests/OctopusDeploymentPlannerTests.cs
@@ -45,7 +45,7 @@ namespace OctopusPuppet.IntegrationTests
             var environmentFrom = ConfigurationManager.AppSettings["EnvironmentFrom"];
             var environmentTo = ConfigurationManager.AppSettings["EnvironmentTo"];
 
-            var dashboard = deploymentPlanner.GetEnvironmentMirrorDeploymentPlans(environmentFrom, environmentTo);
+            var dashboard = deploymentPlanner.GetEnvironmentMirrorDeploymentPlans(environmentFrom, environmentTo, false);
 
             var deploymentScheduler = new DeploymentScheduler();
             var products = deploymentScheduler.GetComponentDeploymentGraph(dashboard.EnvironmentDeploymentPlan);
@@ -65,7 +65,7 @@ namespace OctopusPuppet.IntegrationTests
             var environment = ConfigurationManager.AppSettings["EnvironmentFrom"];
             var branch = "Master";
 
-            var dashboard = deploymentPlanner.GetBranchDeploymentPlans(environment, branch);
+            var dashboard = deploymentPlanner.GetBranchDeploymentPlans(environment, branch, false);
 
             var difference = JsonConvert.SerializeObject(dashboard.EnvironmentDeploymentPlan.DeploymentPlans.Where(x => x.Action != PlanAction.Skip));
 

--- a/src/OctopusPuppet/DeploymentPlanner/IDeploymentPlanner.cs
+++ b/src/OctopusPuppet/DeploymentPlanner/IDeploymentPlanner.cs
@@ -6,8 +6,8 @@ namespace OctopusPuppet.DeploymentPlanner
     {
         List<Environment> GetEnvironments();
         List<Branch> GetBranches();
-        EnvironmentDeploymentPlans GetEnvironmentMirrorDeploymentPlans(string environmentFrom, string environmentTo, ComponentFilter componentFilter = null);
-        BranchDeploymentPlans GetBranchDeploymentPlans(string environment, string branch, ComponentFilter componentFilter = null);
+        EnvironmentDeploymentPlans GetEnvironmentMirrorDeploymentPlans(string environmentFrom, string environmentTo, bool doNotUseDifferentialDeployment, ComponentFilter componentFilter = null);
+        BranchDeploymentPlans GetBranchDeploymentPlans(string environment, string branch, bool doNotUseDifferentialDeployment, ComponentFilter componentFilter = null);
         RedeployDeploymentPlans GetRedeployDeploymentPlans(string environment, ComponentFilter componentFilter = null);
     }
 }

--- a/teamcity-plugin/Solutions/server/metaRunners/MRPLUGIN_OctopusPuppetBranchDeployment.xml
+++ b/teamcity-plugin/Solutions/server/metaRunners/MRPLUGIN_OctopusPuppetBranchDeployment.xml
@@ -15,6 +15,7 @@
       <param name="teamcity.tool.microsoft.octopuspuppet.hidedeploymentprogress" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Hide deployment progress.' display='normal' label='Hide deployment progress:' validationMode=''" />
       <param name="teamcity.tool.microsoft.octopuspuppet.updatevariables" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Update Variables.' display='normal' label='Update Variables:' validationMode=''" />
       <param name="teamcity.tool.microsoft.octopuspuppet.deploy" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Deploy.' display='normal' label='Deploy:' validationMode=''" />
+      <param name="teamcity.tool.microsoft.octopuspuppet.donotusedifferentialdeployment" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Do not use differential deployment.' display='normal' label='Do not use differential deployment:' validationMode=''" />
       <param name="teamcity.tool.microsoft.octopuspuppet.maximumparalleldeployments" value="" spec="text description='Maximum parallel deployments' display='normal' label='Maximum parallel deployments:' validationMode=''" />
     </parameters>
     <build-runners>
@@ -44,6 +45,7 @@ $componentFilter = @'
 $environmentDeploymentPath = "%teamcity.tool.microsoft.octopuspuppet.environmentdeploymentpath%"
 $hideDeploymentProgress = "%teamcity.tool.microsoft.octopuspuppet.hidedeploymentprogress%" -eq 'true'
 $deploy = "%teamcity.tool.microsoft.octopuspuppet.deploy%" -eq 'true'
+$doNotUseDifferentialDeployment = "%teamcity.tool.microsoft.octopuspuppet.donotusedifferentialdeployment%" -eq 'true'
 $updateVariables = "%teamcity.tool.microsoft.octopuspuppet.updatevariables%" -eq 'true'
 $maximumParallelDeployments = "%teamcity.tool.microsoft.octopuspuppet.maximumparalleldeployments%"
 
@@ -72,6 +74,10 @@ try
     if ($deploy){
         $command += " --Deploy"
     }
+
+    if ($doNotUseDifferentialDeployment){
+        $command += " --DoNotUseDifferentialDeployment"
+    }    
 
     if ($updateVariables){
         $command += " --UpdateVariables"

--- a/teamcity-plugin/Solutions/server/metaRunners/MRPLUGIN_OctopusPuppetMirrorEnvironment.xml
+++ b/teamcity-plugin/Solutions/server/metaRunners/MRPLUGIN_OctopusPuppetMirrorEnvironment.xml
@@ -15,6 +15,7 @@
       <param name="teamcity.tool.microsoft.octopuspuppet.hidedeploymentprogress" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Hide deployment progress.' display='normal' label='Hide deployment progress:' validationMode=''" />
       <param name="teamcity.tool.microsoft.octopuspuppet.updatevariables" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Update Variables.' display='normal' label='Update Variables:' validationMode=''" />
       <param name="teamcity.tool.microsoft.octopuspuppet.deploy" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Deploy.' display='normal' label='Deploy:' validationMode=''" />
+      <param name="teamcity.tool.microsoft.octopuspuppet.donotusedifferentialdeployment" value="" spec="checkbox checkedValue='true' uncheckedValue='false' description='Do not use differential deployment.' display='normal' label='Do not use differential deployment:' validationMode=''" />
       <param name="teamcity.tool.microsoft.octopuspuppet.maximumparalleldeployments" value="" spec="text description='Maximum parallel deployments' display='normal' label='Maximum parallel deployments:' validationMode=''" />
     </parameters>
     <build-runners>
@@ -44,6 +45,7 @@ $componentFilter = @'
 $environmentDeploymentPath = "%teamcity.tool.microsoft.octopuspuppet.environmentdeploymentpath%"
 $hideDeploymentProgress = "%teamcity.tool.microsoft.octopuspuppet.hidedeploymentprogress%" -eq 'true'
 $deploy = "%teamcity.tool.microsoft.octopuspuppet.deploy%" -eq 'true'
+$doNotUseDifferentialDeployment = "%teamcity.tool.microsoft.octopuspuppet.donotusedifferentialdeployment%" -eq 'true'
 $updateVariables = "%teamcity.tool.microsoft.octopuspuppet.updatevariables%" -eq 'true'
 $maximumParallelDeployments = "%teamcity.tool.microsoft.octopuspuppet.maximumparalleldeployments%"
 
@@ -66,6 +68,10 @@ try
 
     if ($deploy){
         $command += " --Deploy"
+    }
+
+    if ($doNotUseDifferentialDeployment){
+        $command += " --DoNotUseDifferentialDeployment"
     }
 
     if ($updateVariables){


### PR DESCRIPTION
- Add a command line switch that will allow you to enable/disable differential deployment for branch and mirror deployments
- Update Teamcity plugin to expose the new functionality
- Update GUI so that we can make use of the new functionality for new starters