### PR TITLE
IXUAT-6125: replaced flagging as 'Remove' for 'Skip' components

### DIFF
--- a/src/OctopusPuppet.IntegrationTests/OctopusPuppet.IntegrationTests.csproj
+++ b/src/OctopusPuppet.IntegrationTests/OctopusPuppet.IntegrationTests.csproj
@@ -105,6 +105,9 @@
       <Name>OctopusPuppet</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
@@ -214,7 +214,14 @@ namespace OctopusPuppet.OctopusProvider
             }
             else if (componentFrom == null)
             {
-                deploymentPlan.Action = PlanAction.Remove;
+                /*
+                 * A release is deployed (e.g. a feature branch) but our desired branch release (e.g. master) doesn't have any release. 
+                 * We should perhaps remove the deployed component (componentTo), but this logic is not implemented at the moment. 
+                 * Octopus would need to have a built-in 'uninstall' feature, which it doesn't.
+                 * In the absence of such feature, components are removed manually.
+                 */ 
+                //deploymentPlan.Action = PlanAction.Remove;
+                deploymentPlan.Action = PlanAction.Skip;
             }
             else if (componentTo == null)
             {

--- a/src/OctopusPuppet.Tests/OctopusPuppet.Tests.csproj
+++ b/src/OctopusPuppet.Tests/OctopusPuppet.Tests.csproj
@@ -115,6 +115,9 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
Replaced flagging as 'Remove' for 'Skip' components during computing the deployment plan. Removal of components via puppet is not supported.

It is not possible to Remove a component/application as there's no inbuilt remove functionality as part of Octopus.
Removing/retiring a component/application is usually done manually by selecting in Octopus the 'stop' and 'uninstall' steps if present.