### PR TITLE
Cloud 615 - Stop adding disabled projects to the deployment plan even if it is a depending component

### DIFF
--- a/src/OctopusPuppet.Cmd/Program.cs
+++ b/src/OctopusPuppet.Cmd/Program.cs
@@ -183,12 +183,12 @@ namespace OctopusPuppet.Cmd
 
             if (updateVariables)
             {
-                yield return new OctopusComponentVertexVariableUpdater(octopusUrl, apiKey);
+                yield return new OctopusComponentVertexVariableUpdater(new OctopusApiSettings(octopusUrl, apiKey));
             }
 
             if (deploy)
             {
-                yield return new OctopusComponentVertexDeployer(octopusUrl, apiKey, environment);
+                yield return new OctopusComponentVertexDeployer(new OctopusApiSettings(octopusUrl, apiKey), environment);
             }
         }
 

--- a/src/OctopusPuppet.Gui/ViewModels/DeploymentPlannerViewModel.cs
+++ b/src/OctopusPuppet.Gui/ViewModels/DeploymentPlannerViewModel.cs
@@ -39,7 +39,7 @@ namespace OctopusPuppet.Gui.ViewModels
             _environmentMirrorToEnvironments = new List<Environment>();
             _selectedEnvironmentMirrorToEnvironment = null;
 
-            _layoutAlgorithmTypes = new List<string>(new []
+            _layoutAlgorithmTypes = new List<string>(new[]
             {
                 "Tree",
                 "Circular",
@@ -411,7 +411,7 @@ namespace OctopusPuppet.Gui.ViewModels
             var componentFilter = new ComponentFilter()
             {
                 Include = ComponentFilterInclude,
-                Expressions = ComponentFilterExpressions.Select(x=>x.Text).ToList()
+                Expressions = ComponentFilterExpressions.Select(x => x.Text).ToList()
             };
 
             var json = JsonConvert.SerializeObject(componentFilter, Formatting.Indented);
@@ -471,7 +471,7 @@ namespace OctopusPuppet.Gui.ViewModels
                     var deploymentPlanner = new OctopusDeploymentPlanner(_apiSettings.Url, _apiSettings.ApiKey);
                     var componentFilter = new ComponentFilter
                     {
-                        Expressions = ComponentFilterExpressions.Select(x=>x.Text).ToList(),
+                        Expressions = ComponentFilterExpressions.Select(x => x.Text).ToList(),
                         Include = ComponentFilterInclude
                     };
 
@@ -567,7 +567,7 @@ namespace OctopusPuppet.Gui.ViewModels
             {
                 try
                 {
-                    var deploymentPlanner = new OctopusDeploymentPlanner(_apiSettings.Url,_apiSettings.ApiKey);
+                    var deploymentPlanner = new OctopusDeploymentPlanner(_apiSettings.Url, _apiSettings.ApiKey);
                     var componentFilter = new ComponentFilter
                     {
                         Expressions = ComponentFilterExpressions.Select(x => x.Text).ToList(),
@@ -639,7 +639,7 @@ namespace OctopusPuppet.Gui.ViewModels
             var saveFileDialog = new SaveFileDialog
             {
                 DefaultExt = "json",
-                Filter =  "Text files (*.json)|*.json|All files (*.*)|*.*",
+                Filter = "Text files (*.json)|*.json|All files (*.*)|*.*",
                 FileName = EnvironmentDeploymentSaveFileName
             };
             if (saveFileDialog.ShowDialog() != true) return;

--- a/src/OctopusPuppet.OctopusProvider/OctopusApiSettings.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusApiSettings.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OctopusPuppet.OctopusProvider
+{
+    public class OctopusApiSettings
+    {
+        public string Url { get; set; }
+        public string ApiKey { get; set; }
+
+        public OctopusApiSettings(string url, string apiKey)
+        {
+            Url = url;
+            ApiKey = apiKey;
+        }
+
+        public bool IsEmpty => string.IsNullOrEmpty(Url) || string.IsNullOrEmpty(ApiKey);
+    }
+}

--- a/src/OctopusPuppet.OctopusProvider/OctopusComponentVertexDeployer.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusComponentVertexDeployer.cs
@@ -19,7 +19,7 @@ namespace OctopusPuppet.OctopusProvider
         private readonly int _timeoutAfterMinutes;
         private readonly OctopusRepository _repository;
 
-        public OctopusComponentVertexDeployer(string url, string apiKey, DeploymentPlanner.Environment environmentToDeployTo, 
+        public OctopusComponentVertexDeployer(OctopusApiSettings apiSettings, DeploymentPlanner.Environment environmentToDeployTo, 
             string comments = "",
             bool forcePackageDownload = false,
             bool forcePackageRedeployment = false,
@@ -32,7 +32,7 @@ namespace OctopusPuppet.OctopusProvider
             _forcePackageRedeployment = forcePackageRedeployment;
             _pollIntervalSeconds = pollIntervalSeconds;
             _timeoutAfterMinutes = timeoutAfterMinutes;
-            var octopusServerEndpoint = new OctopusServerEndpoint(url, apiKey);
+            var octopusServerEndpoint = new OctopusServerEndpoint(apiSettings.Url, apiSettings.ApiKey);
             _repository = new OctopusRepository(octopusServerEndpoint);
         }
 

--- a/src/OctopusPuppet.OctopusProvider/OctopusComponentVertexVariableUpdater.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusComponentVertexVariableUpdater.cs
@@ -12,9 +12,9 @@ namespace OctopusPuppet.OctopusProvider
     {
         private readonly OctopusRepository _repository;
 
-        public OctopusComponentVertexVariableUpdater(string octopusUrl, string octopusApiKey)
+        public OctopusComponentVertexVariableUpdater(OctopusApiSettings apiSettings)
         {
-            _repository = new OctopusRepository(new OctopusServerEndpoint(octopusUrl, octopusApiKey));
+            _repository = new OctopusRepository(new OctopusServerEndpoint(apiSettings.Url, apiSettings.ApiKey));
         }
 
         public ComponentVertexDeploymentResult Deploy(ComponentDeploymentVertex vertex, CancellationToken cancellationToken, ILogMessages logMessages, IProgress<ComponentVertexDeploymentProgress> progress)

--- a/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
@@ -24,7 +24,7 @@ namespace OctopusPuppet.OctopusProvider
                 RefreshCachedProjects();
         }
 
-        private ProjectResource GetProjectById(string id) => _cachedProjects.FirstOrDefault(x => x.Id == id);
+        private ProjectResource GetProjectById(string id) => _cachedProjects.SingleOrDefault(x => x.Id == id);
         private ProjectResource GetProjectByName(string name) => _cachedProjects.FirstOrDefault(x => x.Name == name);
         private void RefreshCachedProjects() => _cachedProjects = _repository.Projects.FindAll();
 
@@ -322,7 +322,7 @@ namespace OctopusPuppet.OctopusProvider
 
             foreach (var dashboardProjectResource in dashboard.Projects)
             {
-                if (_cachedProjects.First(x => x.Id == dashboardProjectResource.Id).IsDisabled)
+                if (GetProjectById(dashboardProjectResource.Id).IsDisabled)
                 {
                     continue;
                 }
@@ -377,7 +377,7 @@ namespace OctopusPuppet.OctopusProvider
 
             foreach (var dashboardProjectResource in dashboard.Projects)
             {
-                if (_cachedProjects.First(x => x.Id == dashboardProjectResource.Id).IsDisabled)
+                if (GetProjectById(dashboardProjectResource.Id).IsDisabled)
                 {
                     continue;
                 }
@@ -427,7 +427,7 @@ namespace OctopusPuppet.OctopusProvider
 
             foreach (var dashboardProjectResource in dashboard.Projects)
             {
-                if (_cachedProjects.First(x => x.Id == dashboardProjectResource.Id).IsDisabled)
+                if (GetProjectById(dashboardProjectResource.Id).IsDisabled)
                 {
                     continue;
                 }

--- a/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
@@ -84,13 +84,13 @@ namespace OctopusPuppet.OctopusProvider
         private List<Branch> GetBranchesForProject(string projectId)
         {
             var branches = from r in GetReleaseResources(projectId)
-                let version = GetSemanticVersionOrNull(r.Version)
-                where version != null
-                select new Branch
-                {
-                    Name = version.SpecialVersion,
-                    Id = version.SpecialVersion
-                };
+                           let version = GetSemanticVersionOrNull(r.Version)
+                           where version != null
+                           select new Branch
+                           {
+                               Name = version.SpecialVersion,
+                               Id = version.SpecialVersion
+                           };
 
             return branches.ToList();
         }
@@ -122,16 +122,16 @@ namespace OctopusPuppet.OctopusProvider
             //Get release for branch
             var releaseResource = releaseResources.FirstOrDefault(x => GetSemanticVersionOrNull(x.Version)?.SpecialVersion == branch);
             if (releaseResource == null) return null;
-            
+
             // No other way to calculate duration otherwise :<
             var dashboardItemResource = GetClosestMatchingDashboardItemResource(dashboard, environmentId, projectId, branch);
 
             var healthy = dashboardItemResource != null && dashboardItemResource.State == TaskState.Success;
 
-            var componentDeployedOnEnvironmentFromDuration = dashboardItemResource == null 
-                ? null 
+            var componentDeployedOnEnvironmentFromDuration = dashboardItemResource == null
+                ? null
                 : dashboardItemResource.CompletedTime - dashboardItemResource.QueueTime;
-            
+
             var projectVariables = _repository.VariableSets.Get(releaseResource.ProjectVariableSetSnapshotId);
 
             var componentDependancies = GetComponentDependancies(componentFilter, projectVariables, releaseResource.Id);
@@ -189,11 +189,11 @@ namespace OctopusPuppet.OctopusProvider
             var componentDeployedOnEnvironmentFromDuration = dashboardItemResource.CompletedTime - dashboardItemResource.QueueTime;
 
             var healthy = dashboardItemResource.State == TaskState.Success;
-            
+
             var release = _repository.Releases.Get(dashboardItemResource.ReleaseId);
             var projectVariables = _repository.VariableSets.Get(release.ProjectVariableSetSnapshotId);
 
- 
+
             var componentDependancies = GetComponentDependancies(componentFilter, projectVariables, dashboardItemResource.ReleaseId);
 
             var component = new Component
@@ -228,7 +228,7 @@ namespace OctopusPuppet.OctopusProvider
                  * We should perhaps remove the deployed component (componentTo), but this logic is not implemented at the moment. 
                  * Octopus would need to have a built-in 'uninstall' feature, which it doesn't.
                  * In the absence of such feature, components are removed manually.
-                 */ 
+                 */
                 //deploymentPlan.Action = PlanAction.Remove;
                 deploymentPlan.Action = PlanAction.Skip;
             }
@@ -269,7 +269,7 @@ namespace OctopusPuppet.OctopusProvider
             var branches = new List<Branch>();
 
             RefreshCachedProjects();
-            
+
             foreach (var project in _cachedProjects)
             {
                 if (project.IsDisabled)
@@ -290,13 +290,13 @@ namespace OctopusPuppet.OctopusProvider
 
         public EnvironmentDeploymentPlans GetEnvironmentMirrorDeploymentPlans(string environmentFrom, string environmentTo, bool doNotUseDifferentialDeployment, ComponentFilter componentFilter = null)
         {
-            var environments = environmentFrom == environmentTo ? 
-                new[] {environmentFrom} : 
-                new[] {environmentFrom, environmentTo};
+            var environments = environmentFrom == environmentTo ?
+                new[] { environmentFrom } :
+                new[] { environmentFrom, environmentTo };
 
             var environmentIds = _repository.Environments
                 .GetAll()
-                .Where(x=>environments.Contains(x.Name))
+                .Where(x => environments.Contains(x.Name))
                 .ToArray();
 
             var environmentReferenceFrom = environmentIds.FirstOrDefault(x => x.Name == environmentFrom);
@@ -311,7 +311,7 @@ namespace OctopusPuppet.OctopusProvider
                 throw new Exception(string.Format("Unable to find environment - {0}", environmentTo));
             }
 
-            var dashboard = _repository.Dashboards.GetDynamicDashboard(null, environmentIds.Select(x=>x.Id).ToArray());
+            var dashboard = _repository.Dashboards.GetDynamicDashboard(null, environmentIds.Select(x => x.Id).ToArray());
 
             var environmentDeploymentPlan = new EnvironmentDeploymentPlans
             {
@@ -322,7 +322,7 @@ namespace OctopusPuppet.OctopusProvider
 
             foreach (var dashboardProjectResource in dashboard.Projects)
             {
-                if (_cachedProjects.First(x=>x.Id == dashboardProjectResource.Id).IsDisabled)
+                if (_cachedProjects.First(x => x.Id == dashboardProjectResource.Id).IsDisabled)
                 {
                     continue;
                 }
@@ -336,9 +336,9 @@ namespace OctopusPuppet.OctopusProvider
 
                 var projectId = dashboardProjectResource.Id;
 
-                var componentFrom = GetComponentForEnvironment(dashboard, environmentReferenceFrom.Id, projectId, componentFilter);                
+                var componentFrom = GetComponentForEnvironment(dashboard, environmentReferenceFrom.Id, projectId, componentFilter);
 
-                var componentTo = environmentReferenceFrom.Id == environmentReferenceTo.Id 
+                var componentTo = environmentReferenceFrom.Id == environmentReferenceTo.Id
                     ? componentFrom
                     : GetComponentForEnvironment(dashboard, environmentReferenceTo.Id, projectId, componentFilter);
 
@@ -365,8 +365,8 @@ namespace OctopusPuppet.OctopusProvider
             {
                 throw new Exception(string.Format("Unable to find environment - {0}", environment));
             }
-            
-            var dashboard = _repository.Dashboards.GetDynamicDashboard(null, environmentIds.Select(x=>x.Id).ToArray());
+
+            var dashboard = _repository.Dashboards.GetDynamicDashboard(null, environmentIds.Select(x => x.Id).ToArray());
 
             var branchDeploymentPlan = new BranchDeploymentPlans
             {
@@ -377,7 +377,7 @@ namespace OctopusPuppet.OctopusProvider
 
             foreach (var dashboardProjectResource in dashboard.Projects)
             {
-                if (_cachedProjects.First(x=>x.Id == dashboardProjectResource.Id).IsDisabled)
+                if (_cachedProjects.First(x => x.Id == dashboardProjectResource.Id).IsDisabled)
                 {
                     continue;
                 }
@@ -417,7 +417,7 @@ namespace OctopusPuppet.OctopusProvider
                 throw new Exception(string.Format("Unable to find environment - {0}", environment));
             }
 
-            var dashboard = _repository.Dashboards.GetDynamicDashboard(null, environmentIds.Select(x=>x.Id).ToArray());
+            var dashboard = _repository.Dashboards.GetDynamicDashboard(null, environmentIds.Select(x => x.Id).ToArray());
 
             var redeployDeploymentPlans = new RedeployDeploymentPlans
             {
@@ -427,7 +427,7 @@ namespace OctopusPuppet.OctopusProvider
 
             foreach (var dashboardProjectResource in dashboard.Projects)
             {
-                if (_cachedProjects.First(x=>x.Id == dashboardProjectResource.Id).IsDisabled)
+                if (_cachedProjects.First(x => x.Id == dashboardProjectResource.Id).IsDisabled)
                 {
                     continue;
                 }

--- a/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
@@ -154,6 +154,7 @@ namespace OctopusPuppet.OctopusProvider
                 return componentDependanciesVariables
                     .SelectMany(x => JsonConvert.DeserializeObject<string[]>(x.Value))
                     .Where(x => componentFilter == null || componentFilter.Match(x))
+                    .Where(x => GetProjectByName(x)?.IsDisabled == false)
                     .ToList();
             }
             catch

--- a/src/OctopusPuppet.OctopusProvider/OctopusPuppet.OctopusProvider.csproj
+++ b/src/OctopusPuppet.OctopusProvider/OctopusPuppet.OctopusProvider.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="OctopusApiSettings.cs" />
     <Compile Include="OctopusComponentVertexDeployer.cs" />
     <Compile Include="OctopusComponentVertexVariableUpdater.cs" />
     <Compile Include="OctopusDeploymentPlanner.cs" />

--- a/src/OctopusPuppet.Tests/OctopusDeploymentPlannerTests.cs
+++ b/src/OctopusPuppet.Tests/OctopusDeploymentPlannerTests.cs
@@ -16,12 +16,21 @@ namespace OctopusPuppet.Tests
         private static OctopusDeploymentPlanner GetSutForVersion(string versionNumber)
         {
             var repo = Substitute.For<IOctopusRepository>();
-            repo.Projects.GetAll().Returns(new List<ReferenceDataItem> { new ReferenceDataItem("123", "") });
 
-            var project = new ProjectResource();
-            repo.Projects.Get("123").Returns(project);
-            repo.Projects.GetReleases(project)
+            var project2 = new ProjectResource("124", "", "Projects-124");
+
+            repo.Projects.GetAll().Returns(new List<ReferenceDataItem> { new ReferenceDataItem("123", "") });
+            repo.Projects.FindAll().Returns(new List<ProjectResource> { project2 });
+
+            var project1 = new ProjectResource() { Id = "123" };
+            repo.Projects.Get("123").Returns(project1);
+            repo.Projects.GetReleases(project1)
                 .Returns(new ResourceCollection<ReleaseResource>(new[] { new ReleaseResource(versionNumber, "123", "") },
+                    new LinkCollection()));
+
+            repo.Projects.Get("124").Returns(project2);
+            repo.Projects.GetReleases(project2)
+                .Returns(new ResourceCollection<ReleaseResource>(new[] { new ReleaseResource(versionNumber, "124", "") },
                     new LinkCollection()));
 
             var sut = new OctopusDeploymentPlanner(repo);


### PR DESCRIPTION
I realised that Octopus Puppet doesn't add a disabled project to the deployment plan, but if it is in the list of ComponentDependencies of a project, it will add it too, without checking if it is disabled.

I had to add some optimizations to keep the same waiting time for loading projects, branches and environments.