### PR TITLE
DO-516 - Reduce default number of releases loaded to 150 for a deployment project

### DIFF
--- a/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
@@ -28,7 +28,7 @@ namespace OctopusPuppet.OctopusProvider
         private ProjectResource GetProjectByName(string name) => _cachedProjects.FirstOrDefault(x => x.Name == name);
         private void RefreshCachedProjects() => _cachedProjects = _repository.Projects.FindAll();
 
-        private List<ReleaseResource> GetReleaseResources(string projectId)
+        private List<ReleaseResource> GetReleaseResources(string projectId, uint maxLastestNumberOfReleaseLookup = 150)
         {
             var project = GetProjectById(projectId);
 
@@ -40,7 +40,9 @@ namespace OctopusPuppet.OctopusProvider
                 var releasePages = _repository.Projects.GetReleases(project, skip);
                 releases.AddRange(releasePages.Items);
                 skip += releasePages.ItemsPerPage;
-                shouldPage = releasePages.TotalResults > skip;
+                shouldPage = maxLastestNumberOfReleaseLookup == 0 
+                    ? releasePages.TotalResults > skip 
+                    : releasePages.TotalResults > skip && maxLastestNumberOfReleaseLookup > skip;
             } while (shouldPage);
 
             return releases;


### PR DESCRIPTION
It's not necessary to load all the releases, looking at the limited number (150)  of the latest release is enough to workout the active work steams. Older releases are anyway obsolete.