### PR TITLE
update regex and also the call to semver to allow release branch to show

### DIFF
--- a/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
+++ b/src/OctopusPuppet.OctopusProvider/OctopusDeploymentPlanner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Octopus.Client;
 using Octopus.Client.Model;
@@ -40,8 +41,8 @@ namespace OctopusPuppet.OctopusProvider
                 var releasePages = _repository.Projects.GetReleases(project, skip);
                 releases.AddRange(releasePages.Items);
                 skip += releasePages.ItemsPerPage;
-                shouldPage = maxLastestNumberOfReleaseLookup == 0 
-                    ? releasePages.TotalResults > skip 
+                shouldPage = maxLastestNumberOfReleaseLookup == 0
+                    ? releasePages.TotalResults > skip
                     : releasePages.TotalResults > skip && maxLastestNumberOfReleaseLookup > skip;
             } while (shouldPage);
 
@@ -71,10 +72,10 @@ namespace OctopusPuppet.OctopusProvider
             return dashboardItemResource;
         }
 
-        private SemanticVersion GetSemanticVersionOrNull(string versionString)
+        private SemVer GetSemanticVersionOrNull(string versionString)
         {
-            SemanticVersion version;
-            SemanticVersion.TryParse(versionString, out version);
+            SemVer version;
+            SemVer.TryParse(versionString, out version);
             return version;
         }
 

--- a/src/OctopusPuppet/DeploymentPlanner/SemVer.cs
+++ b/src/OctopusPuppet/DeploymentPlanner/SemVer.cs
@@ -18,8 +18,8 @@ namespace OctopusPuppet.DeploymentPlanner
     [JsonConverter(typeof(SemVerJsonConverter))]
     public sealed class SemVer : IComparable, IComparable<SemVer>, IEquatable<SemVer>
     {
-        private static readonly Regex SemanticVersionRegex = new Regex("^(?<Version>\\d+(\\s*\\.\\s*\\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
-        private static readonly Regex StrictSemanticVersionRegex = new Regex("^(?<Version>\\d+(\\.\\d+){2})(?<Release>-[a-z][0-9a-z-]*)?$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
+        private static readonly Regex SemanticVersionRegex = new Regex(@"^(?<Version>\d+(\.\d+){1,3})(?<Release>-[A-Za-z][0-9A-Za-z.-]*)?$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
+        private static readonly Regex StrictSemanticVersionRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>-[A-Za-z][0-9A-Za-z.-]*)?$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled);
         private const RegexOptions _flags = RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled;
         private readonly string _originalString;
 


### PR DESCRIPTION
Updated SemVer regex to include releases like `release-1.5.1` while preserving original behavior.  
Ensures dropdown only shows valid versions, preventing single numbers or invalid strings from appearing.